### PR TITLE
feat: set project name by CLI argument

### DIFF
--- a/.changeset/late-timers-tease.md
+++ b/.changeset/late-timers-tease.md
@@ -1,0 +1,5 @@
+---
+"temp-gen": minor
+---
+
+set project name by command line argument

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # temp-gen
 
 Interactive CLI to start a template generation CLI tool.
+
+## Usage
+
+| Argument/Option | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| [directory]     | Include a directory argument with a name for the project |

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@clack/core": "^0.3.4",
     "@clack/prompts": "^0.7.0",
     "chalk": "^5.3.0",
+    "commander": "^12.1.0",
     "fs-extra": "^11.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -723,6 +726,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2754,6 +2761,8 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  commander@12.1.0: {}
 
   commander@4.1.1: {}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,15 +1,32 @@
 import * as p from "@clack/prompts";
+import { Command } from "commander";
 
 import { validateProjectName } from "@/cli/validateProjectName.js";
-import { DEFAULT_PROJECT_NAME } from "@/constants.js";
+import { CLI_TOOL_NAME, DEFAULT_PROJECT_NAME } from "@/constants.js";
 
 export const runCli = () => {
+  const command = new Command()
+    .name(CLI_TOOL_NAME)
+    .description("A CLI for creating JS/TS project template generator.")
+    .argument(
+      "[directory]",
+      "The name of the generator, as well as the name of the directory to create",
+    )
+    .parse();
+
+  const projectNameFromCommand = command.args[0];
+  if (projectNameFromCommand) {
+    return {
+      projectName: projectNameFromCommand,
+    };
+  }
+
   return p.group({
     projectName: () => {
       return p.text({
         message: "What will your project be called?",
-        validate: validateProjectName,
         defaultValue: DEFAULT_PROJECT_NAME,
+        validate: validateProjectName,
       });
     },
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,6 @@ const outputFilePath = fileURLToPath(import.meta.url);
 const distPath = path.dirname(outputFilePath);
 export const PACKAGE_ROOT = path.resolve(distPath, "../");
 
+export const CLI_TOOL_NAME = "creat-temp-gen";
+
 export const DEFAULT_PROJECT_NAME = "my-temp-gen";


### PR DESCRIPTION
# Description

Users can set project name by CLI argument.

# Changelog

- build: add commander
- feat: set project name by CLI argument
- docs: add description of CLI arguments

https://github.com/user-attachments/assets/9d5e9ece-ca1e-4a40-a229-57643a7ee913

